### PR TITLE
ci: add workflow_dispatch trigger to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` trigger to workflows that were missing it.

**Files updated:**
- `.github/workflows/ci.yml`

**Why:** Manual/on-demand workflow triggering was not possible without this trigger.

---
*Created by Forge (JarvisXomware)*